### PR TITLE
Building a static binary for Linux using Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
-    - name: libGMP
-      run: wget --progress=dot:mega https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2 ; tar xjf gmp-6.2.1.tar.bz2 ; cd gmp-6.2.1 ; ./configure --enable-cxx --enable-fat --prefix=$(pwd)/../usr/local ; make -j ; make install ; cd .. ;    
     - name: configure
       run: ./Config-all ; cd bin-release/ ; make ; strip -s src/smart ; mkdir ../website ; cp src/smart ../website ; cd ..
     - name: Deploy to GitHub Pages

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,10 +3,6 @@ name: Linux Build
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  repository_dispatch:
-    types: [Linux]
 
 jobs:
   build:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,28 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  repository_dispatch:
+    types: [Linux]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+    - name: libGMP
+      run: wget --progress=dot:mega https://gmplib.org/download/gmp/gmp-6.2.1.tar.bz2 ; tar xjf gmp-6.2.1.tar.bz2 ; cd gmp-6.2.1 ; ./configure --enable-cxx --enable-fat --prefix=$(pwd)/../usr/local ; make -j ; make install ; cd .. ;    
+    - name: configure
+      run: ./Config-all ; cd bin-release/ ; make ; strip -s src/smart ; mkdir ../website ; cp src/smart ../website ; cd ..
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: website/ # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch 
+          single-commit: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.4.1
       with:
-          branch: gh-pages # The branch the action should deploy to.
+          branch: linux # The branch the action should deploy to.
           folder: website/ # The folder the action should deploy.
           clean: true # Automatically remove deleted files from the deploy branch 
           single-commit: true

--- a/Config-all
+++ b/Config-all
@@ -91,7 +91,7 @@ export CC=gcc
 export CXX=g++
 export CXXFLAGS="$CXXFLAGS -Wall -std=c++11 -DNDEBUG"
 export CPPFLAGS=""
-export LDFLAGS="$LDFLAGS -static -static-libgcc -static-libstdc++ -flto -fwhole-program"
+export LDFLAGS="$LDFLAGS -static -static-libgcc -static-libstdc++"
 
 GMP_STATUS=""
 

--- a/Config-all
+++ b/Config-all
@@ -89,10 +89,9 @@ printf "\n"
 
 export CC=gcc
 export CXX=g++
-export CXXFLAGS="$CXXFLAGS -Wall -std=c++11"
-export LDFLAGS="" 
+export CXXFLAGS="$CXXFLAGS -Wall -std=c++11 -DNDEBUG"
 export CPPFLAGS=""
-
+export LDFLAGS="$LDFLAGS -static -static-libgcc -static-libstdc++ -flto -fwhole-program"
 
 GMP_STATUS=""
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,7 @@ AX_CXX_COMPILE_STDCXX(11)
 AM_PROG_LEX
 AC_PROG_YACC
 # Use AM_PROG_AR if we can...
-m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AM_PROG_LIBTOOL
+LT_INIT([disable-shared])
 
 #
 # Check for GMP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,9 @@ BUILT_SOURCES = \
 AM_YFLAGS = -d
 AM_CXXFLAGS = -Wall
 
+smart_LDFLAGS=${LDFLAGS} -all-static
+smart_CXXFLAGS =${CXXFLAGS} -Wall -O3 -DNDEBUG
+
 ## ============================================================
 ##
 ## SMART
@@ -153,7 +156,7 @@ smart_SOURCES = \
   Apps/smart.cc
 
 
-smart_LDADD = _Meddly/src/libmeddly.la
+smart_LDADD = _Meddly/src/.libs/libmeddly.a
 
 
 ## ============================================================

--- a/src/_GraphLib/graphlib.cc
+++ b/src/_GraphLib/graphlib.cc
@@ -9,7 +9,7 @@
 
 // External libraries
 
-#include "intset.h"
+#include "../_IntSets/intset.h"
 
 const int MAJOR_VERSION = 3;
 const int MINOR_VERSION = 0;

--- a/src/_Meddly/Makefile.am
+++ b/src/_Meddly/Makefile.am
@@ -3,5 +3,6 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src examples tests
+SUBDIRS = src 
+#examples tests
 DIST_SUBDIRS = $(SUBDIRS) doxygen doxygen-devel


### PR DESCRIPTION
The minor edits to configure/make flags essentially allow to build a full static link of smart, resulting in a Linux binary ~6MB that is dependency-less. In particular it is not libc version dependent.

The .github/ folder contributes automatic build of smart and then uploads the resulting static binary back to github.
The files are pretty self explanatory. The dependabot thing will submit patches automatically if the versions referenced in the linux.yml are updated.

This results in : 

Actions tab https://github.com/yanntm/smart/actions

Built artefact : 
https://github.com/yanntm/smart/tree/linux

So we can provide an easy download link : https://github.com/yanntm/smart/raw/linux/smart

We could adapt the flows to also build win and osx versions, I do have examples.

I hope these edits don't break something, I did not look at debug version
Maybe my line 20 of src/Makefile.am
`smart_CXXFLAGS =${CXXFLAGS} -Wall -O3 -DNDEBUG`
is not necessary.

