### PR TITLE
Automate build using GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "04:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,22 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+    - name: configure
+      run: ./Config-all ; cd bin-release/ ; make ; strip -s src/smart ; mkdir ../website ; cp src/smart ../website ; cd ..
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      with:
+          branch: linux # The branch the action should deploy to.
+          folder: website/ # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch 
+          single-commit: true

--- a/configure.ac
+++ b/configure.ac
@@ -17,9 +17,7 @@ AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX(11)
 AM_PROG_LEX
 AC_PROG_YACC
-# Use AM_PROG_AR if we can...
-m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
-AM_PROG_LIBTOOL
+LT_INIT([disable-shared])
 
 #
 # Check for GMP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,10 +14,10 @@ BUILT_SOURCES = \
   ParseICP/icplex.cc ParseICP/icpyacc.hh ParseICP/icpyacc.cc
 
 AM_YFLAGS = -d
-AM_CXXFLAGS = ${CXXFLAGS} -Wall
+AM_CXXFLAGS = ${CXXFLAGS} -Wall -Wno-sign-compare
 
 smart_LDFLAGS=${LDFLAGS} -all-static
-smart_CXXFLAGS =${CXXFLAGS} -Wall -g
+smart_CXXFLAGS =${CXXFLAGS} -Wall -g -Wno-sign-compare
 
 ## ============================================================
 ##

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,10 @@ BUILT_SOURCES = \
   ParseICP/icplex.cc ParseICP/icpyacc.hh ParseICP/icpyacc.cc
 
 AM_YFLAGS = -d
-AM_CXXFLAGS = -Wall
+AM_CXXFLAGS = ${CXXFLAGS} -Wall
+
+smart_LDFLAGS=${LDFLAGS} -all-static
+smart_CXXFLAGS =${CXXFLAGS} -Wall -g
 
 ## ============================================================
 ##
@@ -165,7 +168,7 @@ smart_SOURCES = \
   Apps/smart.cc
 
 
-smart_LDADD = _Meddly/src/libmeddly.la
+smart_LDADD = _Meddly/src/.libs/libmeddly.a
 
 
 ## ============================================================

--- a/src/_GraphLib/graphlib.cc
+++ b/src/_GraphLib/graphlib.cc
@@ -9,7 +9,7 @@
 
 // External libraries
 
-#include "intset.h"
+#include "../_IntSets/intset.h"
 
 const int MAJOR_VERSION = 3;
 const int MINOR_VERSION = 0;


### PR DESCRIPTION
This patch lets us build smart/meddly automatically using GitHub Actions.

It contributes :
* the .gihtub/ folder with the actual build scripts. Critical file is "linux.yml"
* edited some configure.ac and Makefile.am to force static build. This means smart binary is standalone instead of carrying a dependency to libmeddly.so
* minor patch to one file that was blocking compilation

So with this patch, any time we commit to master branch of smart, a binary is rebuilt and deployed to "linux" branch of the repo, ready for download. I do have similar scripts for osx/win if you'd like to have those too.

Have a look at the Actions tab here to get an idea of the result
https://github.com/yanntm/smart/actions
And of course the actual smart binary built here : https://github.com/yanntm/smart/raw/linux/smart

Hope you like it !

